### PR TITLE
feat/platform_env_config: configure env specific to platform

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -26,10 +26,9 @@ function flatten_configuration(cfg) {
 
     // then apply environment setup
     const node_env = process.env.NODE_ENV || "development";
-    if (env[os.platform()][node_env]) {
-     conf = extend(true, conf, env[os.platform()][node_env]);
-     delete conf[node_env]; 
-    }	  
+    if (env[os.platform()].ENV && env[os.platform()].ENV[node_env]) {
+      conf = extend(true, conf, env[os.platform()].ENV[node_env]);
+    }
     if (env[node_env]) {
       conf = extend(true, conf, env[node_env]);
     }

--- a/cli.js
+++ b/cli.js
@@ -26,6 +26,10 @@ function flatten_configuration(cfg) {
 
     // then apply environment setup
     const node_env = process.env.NODE_ENV || "development";
+    if (env[os.platform()][node_env]) {
+     conf = extend(true, conf, env[os.platform()][node_env]);
+     delete conf[node_env]; 
+    }	  
     if (env[node_env]) {
       conf = extend(true, conf, env[node_env]);
     }


### PR DESCRIPTION
configure env for platform specific dependencies.

For example, libpthread is a dependency only for win32 platforms.
If the dependency has to be configured for a different `targetDir`  for NODE_ENV=dev, the config must be specified specific to the platform.

```
ENV: {
 win32: {
   "lib": {...},
    "ENV": {
      "dev": {}
    }
 }
}
```