### PR TITLE
fix/no_evn: should build if no env is specified

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -26,7 +26,7 @@ function flatten_configuration(cfg) {
 
     // then apply environment setup
     const node_env = process.env.NODE_ENV || "development";
-    if (env[os.platform()].ENV && env[os.platform()].ENV[node_env]) {
+    if (env[os.platform()] && env[os.platform()].ENV && env[os.platform()].ENV[node_env]) {
       conf = extend(true, conf, env[os.platform()].ENV[node_env]);
     }
     if (env[node_env]) {


### PR DESCRIPTION
Should be able to build even if ENV is not specified