### PR TITLE
Update electron downloader

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = (options, cb) => {
 	opts.customFilename = filename;
 	opts.customDir = '/';
 	opts.avoidMiddleUrl = true;
-	opts.cache = path.resolve('./lib_zips' );
+	opts.cache = path.resolve( os.tmpdir(), 'lib_zips' );
 	console.log('opts being passed innnnn', opts)
 
 	return downloader(opts, (err, zipPath) => {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-const downloader = require('electron-download-fork');
+// const downloader = require('electron-download-fork');
+const downloader = require('electron-download');
 const unzip = require('unzip');
 const os = require('os');
 const fs = require('fs');
@@ -53,7 +54,12 @@ module.exports = (options, cb) => {
 	const filename = prefix + "-" + opts.version + "-" + opts.platform + "-" + opts.arch + '.zip';
 	const targetFilePattern = new RegExp(options.filePattern || '^(' + prefix + '|(lib)' + prefix +'.*\.(dll|so|dylib))$');
 
+
 	opts.customFilename = filename;
+	opts.customDir = '/';
+	opts.avoidMiddleUrl = true;
+	opts.cache = path.resolve('./lib_zips' );
+	console.log('opts being passed innnnn', opts)
 
 	return downloader(opts, (err, zipPath) => {
 		checkError(err);
@@ -63,7 +69,7 @@ module.exports = (options, cb) => {
 		  .pipe(unzip.Parse())
 		  .on('entry', entry => {
 			const fileName = path.basename(entry.path);
-			const type = entry.type; // 'Directory' or 'File' 
+			const type = entry.type; // 'Directory' or 'File'
 			if (type == 'File' && fileName.match(targetFilePattern)) {
 				// only put the specific files into our target dir
 				targetFiles.push(fileName)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deps_downloader",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "Download libs for your platform and unpack them automatically on install",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "async": "^2.1.5",
-    "electron-download-fork": "https://s3.eu-west-2.amazonaws.com/electron-download-fork/electron-download-fork-4.1.0.tgz",
+    "electron-download": "git+https://github.com/joshuef/electron-download#SafeEnabled",
     "extend": "^3.0.0",
     "minimalist": "^1.0.0",
     "unzip": "^0.1.11"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deps_downloader",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Download libs for your platform and unpack them automatically on install",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deps_downloader",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Download libs for your platform and unpack them automatically on install",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "async": "^2.1.5",
-    "electron-download": "git+https://github.com/joshuef/electron-download#SafeEnabled",
+    "electron-download": "git+https://github.com/joshuef/electron-download#COPY",
     "extend": "^3.0.0",
     "minimalist": "^1.0.0",
     "unzip": "^0.1.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,13 +152,19 @@ debug@^2.1.3, debug@^2.2.0:
   dependencies:
     ms "2.0.0"
 
+debug@^3.0.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deep-extend@~0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -170,19 +176,19 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-"electron-download-fork@https://s3.eu-west-2.amazonaws.com/electron-download-fork/electron-download-fork-4.1.0.tgz":
-  version "4.1.0"
-  resolved "https://s3.eu-west-2.amazonaws.com/electron-download-fork/electron-download-fork-4.1.0.tgz#905bb52bb17bc9e52fd8dd0206523cfdbe78566b"
+"electron-download@git+https://github.com/joshuef/electron-download#debugVsafe":
+  version "4.1.1"
+  resolved "git+https://github.com/joshuef/electron-download#3dcdfa631e23df6d7e981933bf2eb39a1e6751ad"
   dependencies:
-    debug "^2.2.0"
+    debug "^3.0.0"
     env-paths "^1.0.0"
-    fs-extra "^2.0.0"
+    fs-extra "^4.0.1"
     minimist "^1.2.0"
-    nugget "^2.0.0"
+    nugget "^2.0.1"
     path-exists "^3.0.0"
-    rc "^1.1.2"
-    semver "^5.3.0"
-    sumchecker "^2.0.1"
+    rc "^1.2.1"
+    semver "^5.4.1"
+    sumchecker "^2.0.2"
 
 env-paths@^1.0.0:
   version "1.0.0"
@@ -221,12 +227,13 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-fs-extra@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
+fs-extra@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   dependencies:
     graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -385,9 +392,9 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
-jsonfile@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -489,6 +496,10 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+
 natives@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31"
@@ -502,7 +513,7 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-nugget@^2.0.0:
+nugget@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/nugget/-/nugget-2.0.1.tgz#201095a487e1ad36081b3432fa3cada4f8d071b0"
   dependencies:
@@ -617,11 +628,11 @@ qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-rc@^1.1.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
+rc@^1.2.1:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   dependencies:
-    deep-extend "~0.4.0"
+    deep-extend "^0.6.0"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
@@ -709,9 +720,13 @@ safe-buffer@^5.0.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0:
+"semver@2 || 3 || 4 || 5":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
+semver@^5.4.1:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
 "setimmediate@>= 1.0.1 < 2", "setimmediate@>= 1.0.2 < 2":
   version "1.0.5"
@@ -809,7 +824,7 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-sumchecker@^2.0.1:
+sumchecker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-2.0.2.tgz#0f42c10e5d05da5d42eea3e56c3399a37d6c5b3e"
   dependencies:
@@ -849,6 +864,10 @@ tunnel-agent@^0.6.0:
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
 unzip@^0.1.11:
   version "0.1.11"


### PR DESCRIPTION
Fix for windows CI where EPERMS errors are rife due to cached folder rename protections.

We use COPY instead of MOVE to quiet things down.